### PR TITLE
feat: introduce executor

### DIFF
--- a/common/src/task_info.rs
+++ b/common/src/task_info.rs
@@ -2,8 +2,8 @@ use alloy_primitives::B256;
 
 #[derive(Clone, Debug, Default)]
 pub struct TaskInfo {
-    l2_hash: B256,
-    l1_head_hash: B256,
+    pub l2_hash: B256,
+    pub l1_head_hash: B256,
 }
 
 impl TaskInfo {

--- a/witnessgen/src/executor.rs
+++ b/witnessgen/src/executor.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use crate::{types::WitnessResult, utils::generate_witness_impl, witness_db::WitnessDB};
+use kroma_common::task_info::TaskInfo;
+
+pub struct Executor {
+    rx: tokio::sync::mpsc::Receiver<TaskInfo>,
+    witness_db: Arc<WitnessDB>,
+}
+
+impl Executor {
+    pub fn new(rx: tokio::sync::mpsc::Receiver<TaskInfo>, witness_db: Arc<WitnessDB>) -> Self {
+        Self { rx, witness_db }
+    }
+
+    pub async fn run(&mut self) {
+        while let Some(task_info) = self.rx.recv().await {
+            let l2_hash = task_info.l2_hash;
+            let l1_head_hash = task_info.l1_head_hash;
+
+            // Trying to generate a witness.
+            let sp1_stdin = generate_witness_impl(l2_hash, l1_head_hash).await;
+
+            // Store the witness to db.
+            match sp1_stdin {
+                Ok(value) => {
+                    tracing::info!("successfully witness result generated");
+                    self.witness_db.set(&l2_hash, &l1_head_hash, value.buffer).unwrap();
+                }
+                Err(e) => {
+                    tracing::info!("failed to generate witness: {:?}", e);
+                    self.witness_db
+                        .set(&l2_hash, &l1_head_hash, WitnessResult::EMPTY_WITNESS)
+                        .unwrap();
+                }
+            }
+        }
+    }
+}

--- a/witnessgen/src/lib.rs
+++ b/witnessgen/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod executor;
 pub mod interface;
 pub mod types;
 pub mod utils;

--- a/witnessgen/src/types.rs
+++ b/witnessgen/src/types.rs
@@ -48,6 +48,8 @@ impl Default for WitnessResult {
 }
 
 impl WitnessResult {
+    pub const EMPTY_WITNESS: Vec<Vec<u8>> = Vec::new();
+
     pub fn new<T: ToString>(status: RequestResult, witness: T) -> Self {
         Self { status, program_key: PROGRAM_KEY.to_string(), witness: witness.to_string() }
     }


### PR DESCRIPTION
This PR addresses an issue where the `native_host_runner` would crash without returning an `Err()`, resulting in the failure to properly handle witness generation failure cases. Additionally, an `Executor` has been introduced to spawn the `native_host_runner` and wait for its termination.