### PR TITLE
feat: support kroma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "kona-client"
 version = "0.1.0"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3888,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "kona-common"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "cfg-if 1.0.0",
  "linked_list_allocator",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "kona-common-proc"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "kona-derive"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "kona-executor"
 version = "0.0.2"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "kona-host"
 version = "0.1.0"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3991,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "kona-mpt"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.10",
@@ -4006,7 +4006,7 @@ dependencies = [
 [[package]]
 name = "kona-preimage"
 version = "0.0.3"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-primitives 0.8.10",
  "async-trait",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "kona-primitives"
 version = "0.0.2"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.10",
@@ -4035,7 +4035,7 @@ dependencies = [
 [[package]]
 name = "kona-providers"
 version = "0.0.1"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.10",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "kona-providers-alloy"
 version = "0.0.1"
-source = "git+https://github.com/moongate-forks/kona?branch=patch-10-17-kona#5a88fcfc5608a35855a74afa2af509da86d97ba8"
+source = "git+https://github.com/kroma-network/kona?branch=kroma-patch-12-06#f8b1e695c03caf258c6fc78349429d26453ce498"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "op-succinct-client-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/op-succinct?rev=053c73e#053c73e0f71e1a60bc4505cdf746105640077b75"
+source = "git+https://github.com/kroma-network/op-succinct?branch=kroma-patch-12-06#4f440c743ff0e39f2e0423cdd3cdd1f7df567219"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4772,7 +4772,7 @@ dependencies = [
 [[package]]
 name = "op-succinct-host-utils"
 version = "0.1.0"
-source = "git+https://github.com/succinctlabs/op-succinct?rev=053c73e#053c73e0f71e1a60bc4505cdf746105640077b75"
+source = "git+https://github.com/kroma-network/op-succinct?branch=kroma-patch-12-06#4f440c743ff0e39f2e0423cdd3cdd1f7df567219"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,13 +56,13 @@ op-alloy-genesis = { version = "0.4.0", default-features = false, features = [
 op-alloy-protocol = { version = "0.4.0", default-features = false }
 
 # kona
-kona-primitives = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-executor = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-client = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-host = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-derive = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-mpt = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
-kona-providers = { git = "https://github.com/moongate-forks/kona", branch = "patch-10-17-kona" }
+kona-primitives = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
+kona-executor = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
+kona-client = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
+kona-host = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
+kona-derive = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
+kona-mpt = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
+kona-providers = { git = "https://github.com/kroma-network/kona", branch = "kroma-patch-12-06" }
 
 # sp1
 sp1-zkvm = { version = "3.0.0", features = ["verify"] }
@@ -70,8 +70,8 @@ sp1-sdk = { version = "3.0.0" }
 sp1-build = { version = "3.0.0" }
 
 # op-succinct
-op-succinct-client-utils = { git = "https://github.com/succinctlabs/op-succinct", rev = "053c73e" }
-op-succinct-host-utils = { git = "https://github.com/succinctlabs/op-succinct", rev = "053c73e" }
+op-succinct-client-utils = { git = "https://github.com/kroma-network/op-succinct", branch = "kroma-patch-12-06" }
+op-succinct-host-utils = { git = "https://github.com/kroma-network/op-succinct", branch = "kroma-patch-12-06" }
 
 # kroma
 kroma-common = { path = "common" }

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ run-witness-scenario l2_hash l1_head_hash witness_store="/tmp/witness_store" wit
     # build the witness generator.
     cargo build --release --bin witness-gen-server
 
-    # Run the witness generator in he backgound.
+    # Run the witness generator in the background.
     ./target/release/witness-gen-server --data {{witness_store}} &
     witness_pid=$!
     
@@ -30,7 +30,7 @@ run-proof-scenario l2_hash l1_head_hash proof_store="/tmp/proof_store" witness_d
     # build the prover.
     cargo build --release --bin prover-proxy
 
-    # Run the prover in he backgound.
+    # Run the prover in the background.
     ./target/release/prover-proxy --data {{proof_store}} &
     prover_pid=$!
 

--- a/justfile
+++ b/justfile
@@ -43,7 +43,7 @@ run-proof-scenario l2_hash l1_head_hash proof_store="/tmp/proof_store" witness_d
     --witness-data {{witness_data}} \
     --proof-data {{proof_data}}
 
-run-onchain-verify proof_data="/tmp/proof.json":
+run-onchain-verify proof_data="proof.json":
     #!/usr/bin/env sh
     anvil --accounts 1 &
     geth_pid=$!
@@ -65,8 +65,8 @@ run-integration-tests l2_hash="0x564ec49e7c9ea0fe167c0ed3796b9c4ba884e059865c525
     #!/usr/bin/env sh
     WITNESS_STORE_PATH="/tmp/witness_store"
     PROOF_STORE_PATH="/tmp/proof_store"
-    WITNESS_DATA="/tmp/witness.json"
-    PROOF_DATA="/tmp/proof.json"
+    WITNESS_DATA="witness.json"
+    PROOF_DATA="proof.json"
     
     just run-witness-scenario {{l2_hash}} {{l1_head_hash}} $WITNESS_STORE_PATH $WITNESS_DATA
     
@@ -74,5 +74,5 @@ run-integration-tests l2_hash="0x564ec49e7c9ea0fe167c0ed3796b9c4ba884e059865c525
     
     # just run-onchain-verify $PROOF_DATA
 
-    rm -rf $WITNESS_DATA
-    rm -rf $PROOF_DATA
+    # rm -rf $WITNESS_DATA
+    # rm -rf $PROOF_DATA

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ run-integration-tests l2_hash="0x564ec49e7c9ea0fe167c0ed3796b9c4ba884e059865c525
     
     just run-proof-scenario {{l2_hash}} {{l1_head_hash}} $PROOF_STORE_PATH $WITNESS_DATA $PROOF_DATA
     
-    just run-onchain-verify $PROOF_DATA
+    # just run-onchain-verify $PROOF_DATA
 
     rm -rf $WITNESS_DATA
     rm -rf $PROOF_DATA

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -36,4 +36,5 @@ sp1-zkvm = { workspace = true }
 op-succinct-client-utils.workspace = true
 
 [features]
+default = ["kroma"]
 kroma = []

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -8,8 +8,12 @@ fn get_storage_root<F: TrieProvider, H: TrieHinter>(
     provider: F,
     hinter: H,
 ) -> B256 {
+    #[cfg(not(feature = "kroma"))]
     const L2_TO_L1_MESSAGE_PASSER_ADDRESS: Address =
         address!("4200000000000000000000000000000000000016");
+    #[cfg(feature = "kroma")]
+    const L2_TO_L1_MESSAGE_PASSER_ADDRESS: Address =
+        address!("4200000000000000000000000000000000000003");
 
     let mut trie_db = TrieDB::new(header.state_root, header.clone(), provider, hinter);
     trie_db


### PR DESCRIPTION
In this PR, the prover supports kroma's devnet environment. That is, the prover can proof for kroma's block.

Note that the address of Kroma’s L2ToL1Passer contract is 0x42….03, which is different from Optimism. If it changes to 0x42…16 in the future, it should be updated accordingly.