### PR TITLE
feat: add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Cargo Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.81.0
+
+      - name: Install SP1 toolchain
+        run: curl -L https://sp1.succinct.xyz | bash && ~/.sp1/bin/sp1up && ~/.sp1/bin/cargo-prove prove --version
+
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build native host runner
+        run: cargo build --workspace --bin native_host_runner --release --target-dir target/native_host_runner
+
+      - name: Test
+        run: cargo nextest run --release --workspace --all --features docker
+        env:
+          L2_NODE_RPC: ${{ secrets.L2_NODE_RPC }}
+          L1_RPC: ${{ secrets.L1_RPC }}
+          L1_BEACON_RPC: ${{ secrets.L1_BEACON_RPC }}
+          L2_RPC: ${{ secrets.L2_RPC }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  prepare:
+    name: Dokcer tag
+    runs-on: ubuntu-latest
+    outputs:
+      docker-tag: ${{ steps.docker-tag.outputs.tag }}
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Docker Image Name
+        id: docker-tag
+        run: |
+          # Extract the version from Cargo.toml
+          VERSION=$(grep '^version' Cargo.toml | head -n1 | sed 's/version = "\(.*\)"/\1/')
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+  build:
+    name: Build Docker Images
+    needs: prepare
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.witnessgen.ubuntu
+          push: true
+          tags: kromanetwork/sp1-wit-gen:${{ needs.prepare.outputs.docker-tag }}

--- a/docker/Dockerfile.witnessgen.ubuntu
+++ b/docker/Dockerfile.witnessgen.ubuntu
@@ -1,3 +1,7 @@
+# Stage 1: Builder base
+FROM ubuntu:latest as builder_base
+
+
 # Stage 1: Builder stage - build witnessgen using Ubuntu and Rust
 FROM ubuntu:latest as builder
 WORKDIR /app


### PR DESCRIPTION
This PR adds CI using GitHub Actions. The CI process includes running cargo test and pushing Docker images after building them. The Docker image tag references the version string specified in Cargo.toml.